### PR TITLE
Make identical Stripe Checkout Sessions idempotent

### DIFF
--- a/app/controllers/account/billing/stripe/subscriptions_controller.rb
+++ b/app/controllers/account/billing/stripe/subscriptions_controller.rb
@@ -18,8 +18,12 @@ class Account::Billing::Stripe::SubscriptionsController < Account::ApplicationCo
     unless @team.stripe_customer_id
       session_attributes[:customer_email] = current_membership.email
     end
+    
+    # Stripe requires that Checkout Sessions having different attributes must
+    # have different idempotency keys, so include the updated_at in the key.
+    idempotency_key = "#{t('application.name')}:subscription:#{@subscription.id}:#{@subscription.updated_at.to_i}"
 
-    session = Stripe::Checkout::Session.create(session_attributes)
+    session = Stripe::Checkout::Session.create(session_attributes, idempotency_key: idempotency_key)
 
     redirect_to session.url, allow_other_host: true
   end


### PR DESCRIPTION
Situation – It's easy for users to open duplicate Stripe Checkout Sessions and to pay for the same subscription more than once. This might happen when (e.g.) a user opens a tab to the checkout page, hesitates in his purchase, walks away from the computer… and then at a later time, navigates to the checkout page in a new tab, and completes the purchase. When he then notices the original checkout page, maybe he thinks that it's a sign that the first payment attempt didn't complete successfully, and he clicks to pay again.

Impact – Some of my customers were charged twice for the same product.

Proposed change – Use Stripe API's idempotency key as Stripe intends.

See discussion [here](https://discord.com/channels/836637622432170028/1046454577651785831/1046603688128552990).