### PR TITLE
Handle customer.subscription.deleted webhook event

### DIFF
--- a/app/models/webhooks/incoming/stripe_webhook.rb
+++ b/app/models/webhooks/incoming/stripe_webhook.rb
@@ -32,6 +32,8 @@ class Webhooks::Incoming::StripeWebhook < ApplicationRecord
 
       # Inspect the subscriptions items on this subscription and ensure they're in-sync with our local entries.
       topic.update_included_prices(object.dig("items", "data"))
+    when "customer.subscription.deleted"
+      topic.generic_subscription.update(status: "canceled")
     end
   end
 


### PR DESCRIPTION
Situation – This library doesn't respond to the `customer.subscription.deleted` webhook event.

Impact – When Stripe subscriptions are canceled via the Stripe administration interface, which is a common customer support operation, Bullet Train's subscription records are not updated. These customers incorrectly retain access to their product subscriptions. This happened to my business.

Recommended change – Implement the `customer.subscription.deleted` webhook event by marking the generic subscription as canceled when Stripe says they are canceled.