### PR TITLE
Allow promo codes if product is configured for it

### DIFF
--- a/app/controllers/account/billing/stripe/subscriptions_controller.rb
+++ b/app/controllers/account/billing/stripe/subscriptions_controller.rb
@@ -5,6 +5,7 @@ class Account::Billing::Stripe::SubscriptionsController < Account::ApplicationCo
   # GET/POST /account/billing/stripe/subscriptions/:id/checkout.json
   def checkout
     trial_days = @subscription.generic_subscription.included_prices.map { |ip| ip.price.trial_days }.compact.max
+    allow_promotion_codes = @subscription.generic_subscription.included_prices.map { |ip| ip.price.allow_promotion_codes }.compact.any?
 
     session_attributes = {
       payment_method_types: ["card"],
@@ -12,7 +13,8 @@ class Account::Billing::Stripe::SubscriptionsController < Account::ApplicationCo
       customer: @team.stripe_customer_id,
       client_reference_id: @subscription.id,
       success_url: CGI.unescape(url_for([:refresh, :account, @subscription, session_id: "{CHECKOUT_SESSION_ID}"])),
-      cancel_url: url_for([:account, @subscription.generic_subscription])
+      cancel_url: url_for([:account, @subscription.generic_subscription]),
+      allow_promotion_codes: allow_promotion_codes,
     }
 
     unless @team.stripe_customer_id

--- a/app/controllers/account/billing/stripe/subscriptions_controller.rb
+++ b/app/controllers/account/billing/stripe/subscriptions_controller.rb
@@ -14,7 +14,7 @@ class Account::Billing::Stripe::SubscriptionsController < Account::ApplicationCo
       client_reference_id: @subscription.id,
       success_url: CGI.unescape(url_for([:refresh, :account, @subscription, session_id: "{CHECKOUT_SESSION_ID}"])),
       cancel_url: url_for([:account, @subscription.generic_subscription]),
-      allow_promotion_codes: allow_promotion_codes,
+      allow_promotion_codes: allow_promotion_codes
     }
 
     unless @team.stripe_customer_id


### PR DESCRIPTION
Depends on https://github.com/bullet-train-pro/bullet_train-billing/pull/17

Fixes https://github.com/bullet-train-pro/bullet_train-billing-stripe/issues/5

A product price can be configured to allow promo codes:

```yaml
basic:
  price: basic_2023
  image: "vol1.png"
  limits:
    # snip
  prices:
    basic_monthly_2023:
      amount: 800
      currency: USD
      duration: 1
      interval: month
      allow_promotion_codes: true
    basic_annual_2023:
      amount: 8000
      currency: USD
      duration: 1
      interval: year
      allow_promotion_codes: false
```

When someone goes to subscribe to a plan that supports coupon codes they'll see this during checkout:

![CleanShot 2023-06-20 at 11 00 00](https://github.com/bullet-train-pro/bullet_train-billing/assets/58702/0a8c13eb-3a25-4330-a612-d3bd1b00d2ac)


![CleanShot 2023-06-20 at 11 00 16](https://github.com/bullet-train-pro/bullet_train-billing/assets/58702/037a6bdd-2f28-41d4-b265-ed9932fa910f)
