### PR TITLE
Revert "Revert "Use Teams::Base load hook to insert functionality (#1…

### DIFF
--- a/lib/bullet_train/billing/stripe.rb
+++ b/lib/bullet_train/billing/stripe.rb
@@ -4,7 +4,23 @@ require "bullet_train/billing/stripe/engine"
 module BulletTrain
   module Billing
     module Stripe
-      # Your code goes here...
+      module Teams
+        module Base
+          extend ActiveSupport::Concern
+
+          included do
+            has_many :billing_stripe_subscriptions, class_name: "Billing::Stripe::Subscription", dependent: :destroy, foreign_key: :team_id
+          end
+        end
+      end
+
+      module AbilitySupport
+        def apply_billing_abilities(user)
+          super
+          can :read, Billing::Stripe::Subscription, team_id: user.team_ids
+          can :manage, Billing::Stripe::Subscription, team_id: user.administrating_team_ids
+        end
+      end
     end
   end
 end
@@ -12,3 +28,6 @@ end
 def stripe_billing_enabled?
   ENV["STRIPE_SECRET_KEY"].present?
 end
+
+ActiveSupport.on_load(:bullet_train_teams_base) { include BulletTrain::Billing::Stripe::Teams::Base }
+ActiveSupport.on_load(:bullet_train_billing_ability_support) { prepend BulletTrain::Billing::Stripe::AbilitySupport }

--- a/lib/bullet_train/billing/stripe.rb
+++ b/lib/bullet_train/billing/stripe.rb
@@ -15,10 +15,12 @@ module BulletTrain
       end
 
       module AbilitySupport
+        extend ActiveSupport::Concern
+
         def apply_billing_abilities(user)
           super
-          can :read, Billing::Stripe::Subscription, team_id: user.team_ids
-          can :manage, Billing::Stripe::Subscription, team_id: user.administrating_team_ids
+          can :read, ::Billing::Stripe::Subscription, team_id: user.team_ids
+          can :manage, ::Billing::Stripe::Subscription, team_id: user.administrating_team_ids
         end
       end
     end

--- a/lib/bullet_train/billing/stripe/engine.rb
+++ b/lib/bullet_train/billing/stripe/engine.rb
@@ -2,6 +2,13 @@ module BulletTrain
   module Billing
     module Stripe
       class Engine < ::Rails::Engine
+        initializer "bullet_train-billing.integrate" do
+          config.after_initialize do
+            if defined?(BulletTrain::Billing.provider_subscription_attributes)
+              BulletTrain::Billing.provider_subscription_attributes << :stripe_subscription_id
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
…0)""

This reverts commit 422691852393d61d257de266557c23c60e786c3e.

We need to have released versions of bullet_train and bullet_train-core before we can merge this in. Alternatively, we can avoid the releases, when this library is moved into bullet_train-core.

I'm using the [teams-base-load-hook](https://github.com/bullet-train-co/bullet_train/tree/teams-base-load-hook) branch on the starter repo, which has the updated bundle so it shows the build passing with this.