### PR TITLE
Allow free trials without a credit card

### DIFF
--- a/app/controllers/account/billing/stripe/subscriptions_controller.rb
+++ b/app/controllers/account/billing/stripe/subscriptions_controller.rb
@@ -9,12 +9,16 @@ class Account::Billing::Stripe::SubscriptionsController < Account::ApplicationCo
 
     session_attributes = {
       payment_method_types: ["card"],
-      subscription_data: {items: @subscription.stripe_items}.merge(trial_days ? {trial_period_days: trial_days} : {}),
+      subscription_data: {
+        items: @subscription.stripe_items,
+        trial_settings: {end_behavior: {missing_payment_method: 'cancel'}},
+      }.merge(trial_days ? {trial_period_days: trial_days} : {}),
       customer: @team.stripe_customer_id,
       client_reference_id: @subscription.id,
       success_url: CGI.unescape(url_for([:refresh, :account, @subscription, session_id: "{CHECKOUT_SESSION_ID}"])),
       cancel_url: url_for([:account, @subscription.generic_subscription]),
-      allow_promotion_codes: allow_promotion_codes
+      allow_promotion_codes: allow_promotion_codes,
+      payment_method_collection: 'if_required',
     }
 
     unless @team.stripe_customer_id


### PR DESCRIPTION
To smooth signup, I've added the ability to do a free trial without a credit card required until the free trial period ends

I followed this Stripe guide to add the feature to the gem: https://docs.stripe.com/payments/checkout/free-trials

If you add `trial_days: ` to any of your `prices` in `products.yml` then this works automatically and won't require a payment method when your user selects a plan. 